### PR TITLE
Require LINEAR_API_KEY in .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-github-cli",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "CLI tool for creating GitHub issues with Linear integration",
   "main": "dist/cli.js",
   "bin": {


### PR DESCRIPTION
## Summary
- require `LINEAR_API_KEY` to exist in a discovered `.env` file
- log the `.env` path when the key is found
- exit early with setup guidance when missing

## Test plan
- npm run build

solve: #5